### PR TITLE
Simplify extension config title & display name

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "packwerk-vscode",
   "version": "0.0.5",
   "publisher": "Gusto",
-  "displayName": "packwerk-vscode",
+  "displayName": "Packwerk",
   "description": "execute packwerk check for current Ruby code.",
   "engines": {
     "vscode": "^1.32.0"
@@ -51,7 +51,7 @@
     ],
     "configuration": {
       "type": "object",
-      "title": "Packwerk-VScode configuration",
+      "title": "Packwerk",
       "properties": {
         "ruby.packwerk.executable": {
           "type": "string",


### PR DESCRIPTION
As per https://code.visualstudio.com/api/references/contribution-points#Configuration-schema

> For both the `title` and `displayName` fields, words like "Extension", "Configuration", and "Settings" are redundant.
>
> ✔ `"title": "GitMagic"`
> ❌ `"title": "GitMagic Extension"`
> ❌ `"title": "GitMagic Configuration"`
> ❌ `"title": "GitMagic Extension Configuration Settings"`