### PR TITLE
Add AGENTS.md and CLAUDE.md for AI coding agent guidance

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,5 +1,3 @@
-# AGENTS.md
-
 This file provides guidance to AI coding agents when working with code in this repository.
 
 ## What this project is

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,27 @@
+# AGENTS.md
+
+This file provides guidance to AI coding agents when working with code in this repository.
+
+## What this project is
+
+A Visual Studio Code extension that integrates [packwerk](https://github.com/Shopify/packwerk) checks directly into the editor. It runs `packwerk check` (or `pks check`) on the current Ruby file and surfaces violations inline.
+
+## Commands
+
+```bash
+npm install
+
+# Compile TypeScript
+npm run vscode:prepublish   # production compile (tsc)
+
+# Watch mode during development
+npm run compile             # tsc --watch
+
+# Run tests
+npm test
+```
+
+## Architecture
+
+- `src/` — TypeScript source; extension entry point registers a command that shells out to the packwerk/pks binary and parses its output into VS Code diagnostics
+- `package.json` — declares the VS Code extension manifest, activation events, and contributed commands

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,1 @@
+@AGENTS.md


### PR DESCRIPTION
## Summary

- Adds `AGENTS.md` with codebase guidance for AI coding agents (commands, architecture)
- Adds `CLAUDE.md` containing just `@AGENTS.md`, following the [Claude Code best practice](https://code.claude.com/docs/en/claude-code-on-the-web#best-practices) of sharing a single instruction file across agents

This makes the same guidance available to Claude Code (via `CLAUDE.md` import) and other agents like Codex that look for `AGENTS.md`.